### PR TITLE
FEAT: 대댓글 기능 추가

### DIFF
--- a/src/main/java/com/capstone/dayj/comment/Comment.java
+++ b/src/main/java/com/capstone/dayj/comment/Comment.java
@@ -19,14 +19,15 @@ public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
+    private int parentId;
     
     @Column(nullable = false)
     private String content;
     
-    
     @Column(nullable = false)
     @ColumnDefault("1")
     private boolean commentIsAnonymous;
+    
     
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "app_user_id", referencedColumnName = "id")
@@ -42,8 +43,9 @@ public class Comment extends BaseEntity {
     }
     
     @Builder
-    public Comment(int id, String content, LocalDateTime commentCreateDate, LocalDateTime commentUpdateDate, boolean commentIsAnonymous, AppUser appUser, Post post) {
+    public Comment(int id, int parentId, String content, LocalDateTime commentCreateDate, LocalDateTime commentUpdateDate, boolean commentIsAnonymous, AppUser appUser, Post post) {
         this.id = id;
+        this.parentId = parentId;
         this.content = content;
         this.commentIsAnonymous = commentIsAnonymous;
         this.appUser = appUser;

--- a/src/main/java/com/capstone/dayj/comment/CommentController.java
+++ b/src/main/java/com/capstone/dayj/comment/CommentController.java
@@ -7,37 +7,47 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/post")
+@RequestMapping("/api/post/{post_id}")
 public class CommentController {
-
+    
     CommentService commentService;
-
+    
     public CommentController(CommentService commentService) {
         this.commentService = commentService;
     }
-
-    @PostMapping("/{post_id}/app-user/{app_user_id}/comment")
-    public void createComment(@PathVariable int post_id, @PathVariable int app_user_id, @Valid @RequestBody CommentDto.Request dto){
+    
+    @PostMapping("/app-user/{app_user_id}/comment")
+    public void createComment(@PathVariable int post_id, @PathVariable int app_user_id, @Valid @RequestBody CommentDto.Request dto) {
         commentService.createComment(post_id, app_user_id, dto);
     }
-
-    @GetMapping("/{post_id}/comment")
-    public List<CommentDto.Response> readAllComment(@PathVariable int post_id){
+    
+    @PostMapping("/app-user/{app_user_id}/comment/{comment_id}")
+    public void createReply(@PathVariable int post_id, @PathVariable int app_user_id, @PathVariable int comment_id, @Valid @RequestBody CommentDto.Request dto) {
+        commentService.createReply(post_id, app_user_id, comment_id, dto);
+    }
+    
+    @GetMapping("comment/{comment_id}/reply")
+    public List<CommentDto.Response> readAllReplyByCommentId(@PathVariable int post_id, @PathVariable int comment_id) {
+        return commentService.readAllReplyByCommentId(post_id, comment_id);
+    }
+    
+    @GetMapping("/comment")
+    public List<CommentDto.Response> readAllComment(@PathVariable int post_id) {
         return commentService.readAllComment(post_id);
     }
-
-    @GetMapping("/{post_id}/comment/{comment_id}")
-    public CommentDto.Response readCommentById(@PathVariable int post_id, @PathVariable int comment_id){
+    
+    @GetMapping("/comment/{comment_id}")
+    public CommentDto.Response readCommentById(@PathVariable int post_id, @PathVariable int comment_id) {
         return commentService.readCommentById(post_id, comment_id);
     }
-
-    @PatchMapping("/{post_id}/comment/{comment_id}")
-    public void patchComment(@PathVariable int post_id, @PathVariable int comment_id, @Valid @RequestBody CommentDto.Request dto){
+    
+    @PatchMapping("/comment/{comment_id}")
+    public void patchComment(@PathVariable int post_id, @PathVariable int comment_id, @Valid @RequestBody CommentDto.Request dto) {
         commentService.patchComment(post_id, comment_id, dto);
     }
-
-    @DeleteMapping("/{post_id}/comment/{comment_id}")
-    public void deleteCommentById(@PathVariable int post_id, @PathVariable int comment_id){
+    
+    @DeleteMapping("/comment/{comment_id}")
+    public void deleteCommentById(@PathVariable int post_id, @PathVariable int comment_id) {
         commentService.deleteCommentById(post_id, comment_id);
     }
 }

--- a/src/main/java/com/capstone/dayj/comment/CommentController.java
+++ b/src/main/java/com/capstone/dayj/comment/CommentController.java
@@ -26,10 +26,10 @@ public class CommentController {
         commentService.createReply(post_id, app_user_id, comment_id, dto);
     }
     
-    @GetMapping("comment/{comment_id}/reply")
-    public List<CommentDto.Response> readAllReplyByCommentId(@PathVariable int post_id, @PathVariable int comment_id) {
-        return commentService.readAllReplyByCommentId(post_id, comment_id);
-    }
+//    @GetMapping("comment/{comment_id}/reply")
+//    public List<CommentDto.Response> readAllReplyByCommentId(@PathVariable int post_id, @PathVariable int comment_id) {
+//        return commentService.readAllReplyByCommentId(post_id, comment_id);
+//    }
     
     @GetMapping("/comment")
     public List<CommentDto.Response> readAllComment(@PathVariable int post_id) {

--- a/src/main/java/com/capstone/dayj/comment/CommentDto.java
+++ b/src/main/java/com/capstone/dayj/comment/CommentDto.java
@@ -13,6 +13,7 @@ public class CommentDto {
     @Builder
     public static class Request {
         private int id;
+        private int parentId;
         private String content;
         private boolean commentIsAnonymous;
         private AppUser appUser;
@@ -21,6 +22,7 @@ public class CommentDto {
         public Comment toEntity() {
             return Comment.builder()
                     .id(id)
+                    .parentId(parentId)
                     .content(content)
                     .commentIsAnonymous(commentIsAnonymous)
                     .appUser(appUser)
@@ -32,6 +34,7 @@ public class CommentDto {
     @Getter
     public static class Response {
         private final int id;
+        private final int parentId;
         private final String content;
         private final boolean commentIsAnonymous;
         @JsonIgnore
@@ -41,6 +44,7 @@ public class CommentDto {
         
         public Response(Comment comment) {
             this.id = comment.getId();
+            this.parentId = comment.getParentId();
             this.content = comment.getContent();
             this.commentIsAnonymous = comment.isCommentIsAnonymous();
             this.appUser = comment.getAppUser();

--- a/src/main/java/com/capstone/dayj/comment/CommentService.java
+++ b/src/main/java/com/capstone/dayj/comment/CommentService.java
@@ -19,51 +19,101 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final AppUserRepository appUserRepository;
     private final PostRepository postRepository;
-
+    
     @Transactional
-    public void createComment (int postId, int userId, CommentDto.Request dto) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(()-> new CustomException(ErrorCode.POST_NOT_FOUND));
-        AppUser user = appUserRepository.findById(userId)
+    public void createComment(int post_id, int app_user_id, CommentDto.Request dto) {
+        Post findPost = postRepository.findById(post_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        AppUser findAppUser = appUserRepository.findById(app_user_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
-
-        dto.setAppUser(user);
-        dto.setPost(post);
-
+        
+        dto.setPost(findPost); // 댓글 달 게시물
+        dto.setAppUser(findAppUser); // 댓글 쓴 유저
         commentRepository.save(dto.toEntity());
     }
-
-    @Transactional(readOnly = true)
-    public List<CommentDto.Response> readAllComment(int postId) {
-
-         Post post = postRepository.findById(postId)
-                .orElseThrow(()-> new CustomException(ErrorCode.POST_NOT_FOUND));
-
-        List<Comment> comments = post.getComment();
-
-        return comments.stream().map(CommentDto.Response::new).collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public CommentDto.Response readCommentById(int postId, int commentId){
-        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
-                .orElseThrow(()-> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
-
-        return new CommentDto.Response(comment);
-    }
+    
     @Transactional
-    public void patchComment(int postId, int commentId, CommentDto.Request dto){
-        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
-                .orElseThrow(()-> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
-
+    public void createReply(int post_id, int app_user_id, int comment_id, CommentDto.Request dto) {
+        Post findPost = postRepository.findById(post_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        AppUser findAppUser = appUserRepository.findById(app_user_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
+        Comment findComment = findPost.getComment().stream()
+                .filter(comment -> comment.getId() == comment_id).findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        
+        dto.setPost(findComment.getPost()); // 대댓글을 작성한 게시물
+        dto.setParentId(findComment.getId()); // 대댓글의 부모 댓글
+        dto.setAppUser(findAppUser); // 대댓글 작성자
+        commentRepository.save(dto.toEntity());
+    }
+    
+    
+    @Transactional(readOnly = true)
+    public List<CommentDto.Response> readAllComment(int post_id) {
+        Post findPost = postRepository.findById(post_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        
+        List<Comment> findComments = findPost.getComment();
+        
+        if (findComments.isEmpty()) {
+            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+        
+        return findComments.stream().map(CommentDto.Response::new).collect(Collectors.toList());
+    }
+    
+    @Transactional(readOnly = true)
+    public CommentDto.Response readCommentById(int post_id, int comment_id) {
+        Post findPost = postRepository.findById(post_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        List<Comment> findComments = findPost.getComment();
+        
+        if (findComments.isEmpty()) {
+            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+        
+        Comment findComment = findComments.stream()
+                .filter(comment -> comment.getId() == comment_id).findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        
+        return new CommentDto.Response(findComment);
+    }
+    
+    @Transactional(readOnly = true)
+    public List<CommentDto.Response> readAllReplyByCommentId(int post_id, int comment_id) {
+        Post findPost = postRepository.findById(post_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        List<Comment> findComments = findPost.getComment();
+        
+        if (findComments.isEmpty()) {
+            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+        
+        List<Comment> findReplies = findComments
+                .stream().filter(comment -> comment.getParentId() == comment_id).toList();
+        
+        if (findReplies.isEmpty()) {
+            throw new CustomException(ErrorCode.REPLY_NOT_FOUND);
+        }
+        
+        return findReplies.stream().map(CommentDto.Response::new).collect(Collectors.toList());
+    }
+    
+    
+    @Transactional
+    public void patchComment(int post_id, int comment_id, CommentDto.Request dto) {
+        Comment comment = commentRepository.findByPostIdAndId(post_id, comment_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        
         comment.update(dto.getContent(), dto.isCommentIsAnonymous());
     } // 작성자 본인만 수정 가능
-
+    
     @Transactional
-    public void deleteCommentById(int postId, int commentId){
-        Comment comment = commentRepository.findByPostIdAndId(postId, commentId)
-                .orElseThrow(()-> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
-
+    public void deleteCommentById(int post_id, int comment_id) {
+        Comment comment = commentRepository.findByPostIdAndId(post_id, comment_id)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+        
         commentRepository.delete(comment);
     } // 작성자 본인만 삭제 가능
 }

--- a/src/main/java/com/capstone/dayj/comment/CommentService.java
+++ b/src/main/java/com/capstone/dayj/comment/CommentService.java
@@ -80,25 +80,25 @@ public class CommentService {
         return new CommentDto.Response(findComment);
     }
     
-    @Transactional(readOnly = true)
-    public List<CommentDto.Response> readAllReplyByCommentId(int post_id, int comment_id) {
-        Post findPost = postRepository.findById(post_id)
-                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        List<Comment> findComments = findPost.getComment();
-        
-        if (findComments.isEmpty()) {
-            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
-        }
-        
-        List<Comment> findReplies = findComments
-                .stream().filter(comment -> comment.getParentId() == comment_id).toList();
-        
-        if (findReplies.isEmpty()) {
-            throw new CustomException(ErrorCode.REPLY_NOT_FOUND);
-        }
-        
-        return findReplies.stream().map(CommentDto.Response::new).collect(Collectors.toList());
-    }
+//    @Transactional(readOnly = true)
+//    public List<CommentDto.Response> readAllReplyByCommentId(int post_id, int comment_id) {
+//        Post findPost = postRepository.findById(post_id)
+//                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+//        List<Comment> findComments = findPost.getComment();
+//
+//        if (findComments.isEmpty()) {
+//            throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
+//        }
+//
+//        List<Comment> findReplies = findComments
+//                .stream().filter(comment -> comment.getParentId() == comment_id).toList();
+//
+//        if (findReplies.isEmpty()) {
+//            throw new CustomException(ErrorCode.REPLY_NOT_FOUND);
+//        }
+//
+//        return findReplies.stream().map(CommentDto.Response::new).collect(Collectors.toList());
+//    }
     
     
     @Transactional

--- a/src/main/java/com/capstone/dayj/exception/ErrorCode.java
+++ b/src/main/java/com/capstone/dayj/exception/ErrorCode.java
@@ -9,28 +9,31 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400 BAD_REQUEST: 잘못된 요청
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-
+    
     // 405 METHOD_NOT_ALLOWED: 허용되지 않은 Request Method 호출
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다."),
-
+    
     // 500 INTERNAL_SERVER_ERROR: 내부 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류입니다."),
-
+    
     // 404 PLAN_NOT_FOUND : 계획을 찾을 수 없음
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "계획을 찾을 수 없습니다."),
-
+    
     // 404 FRIEND_GROUP_NOT_FOUND : 계획을 찾을 수 없음
     FRIEND_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
-
+    
     // 404 APP_USER_NOT_FOUND : 회원을 찾을 수 없음
     APP_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
-
+    
     // 404 COMMENT_NOT_FOUND : 댓글을 찾을 수 없음
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
-
+    
+    // 404 REPLY_NOT_FOUND : 대댓글 찾을 수 없음
+    REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "대댓글을 찾을 수 없습니다."),
+    
     // 404 POST_NOT_FOUND : 게시물을 찾을 수 없음
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다.");
-
+    
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/capstone/dayj/plan/PlanController.java
+++ b/src/main/java/com/capstone/dayj/plan/PlanController.java
@@ -25,13 +25,13 @@ public class PlanController {
     }
     
     @GetMapping("/{plan_id}")
-    public PlanDto.Response readPlanById(@PathVariable int app_user_id, @PathVariable int plan_id) {
-        return planService.readPlanById(app_user_id, plan_id);
+    public PlanDto.Response readPlanById(@PathVariable int plan_id) {
+        return planService.readPlanById(plan_id);
     }
     
     @GetMapping("tag/{plan_tag}")
-    public List<PlanDto.Response> readByPlanTag(@PathVariable int app_user_id, @PathVariable String plan_tag) {
-        return planService.readPlanByPlanTag(app_user_id, plan_tag);
+    public List<PlanDto.Response> readByPlanTag(@PathVariable String plan_tag) {
+        return planService.readPlanByPlanTag(plan_tag);
     }
     
     @PatchMapping("/{plan_id}")
@@ -40,7 +40,7 @@ public class PlanController {
     }
     
     @DeleteMapping("/{plan_id}")
-    public void deletePlanById(@PathVariable int app_user_id, @PathVariable int plan_id) {
-        planService.deletePlanById(app_user_id, plan_id);
+    public void deletePlanById(@PathVariable int plan_id) {
+        planService.deletePlanById(plan_id);
     }
 }

--- a/src/main/java/com/capstone/dayj/plan/PlanRepository.java
+++ b/src/main/java/com/capstone/dayj/plan/PlanRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 @Repository
 public interface PlanRepository extends JpaRepository<Plan, Integer> {
     Optional<Plan> findByAppUserIdAndId(Integer appUserId, Integer planId);
-    List<Plan> findAllByAppUserIdAndPlanTag(int appUserId, String planTag);
+    
     List<Plan> findAllByAppUserId(Integer appUserId);
 }

--- a/src/main/java/com/capstone/dayj/plan/PlanService.java
+++ b/src/main/java/com/capstone/dayj/plan/PlanService.java
@@ -6,7 +6,7 @@ import com.capstone.dayj.exception.CustomException;
 import com.capstone.dayj.exception.ErrorCode;
 import com.capstone.dayj.planOption.PlanOptionDto;
 import com.capstone.dayj.planOption.PlanOptionRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -34,7 +34,7 @@ public class PlanService {
         planOptionRepository.save(newPlanOption.toEntity());
     }
     
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PlanDto.Response> readAllPlan(int app_user_id) {
         List<Plan> findPlans = planRepository.findAllByAppUserId(app_user_id);
         
@@ -44,7 +44,7 @@ public class PlanService {
         return findPlans.stream().map(PlanDto.Response::new).collect(Collectors.toList());
     }
     
-    @Transactional
+    @Transactional(readOnly = true)
     public PlanDto.Response readPlanById(int plan_id) {
         Plan findPlan = planRepository.findById(plan_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
@@ -52,7 +52,7 @@ public class PlanService {
         return new PlanDto.Response(findPlan);
     }
     
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PlanDto.Response> readPlanByPlanTag(String planTag) {
         List<Plan> findPlans = planRepository.findAll()
                 .stream().filter(plan -> plan.getPlanTag().equals(planTag)).toList();

--- a/src/main/java/com/capstone/dayj/plan/PlanService.java
+++ b/src/main/java/com/capstone/dayj/plan/PlanService.java
@@ -22,14 +22,14 @@ public class PlanService {
     
     @Transactional
     public void createPlan(int app_user_id, PlanDto.Request dto) {
-        AppUser appUser = appUserRepository.findById(app_user_id)
+        AppUser findAppUser = appUserRepository.findById(app_user_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
         
-        dto.setAppUser(appUser);
-        Plan savedPlan = planRepository.save(dto.toEntity());
-
+        dto.setAppUser(findAppUser);
+        Plan newPlan = planRepository.save(dto.toEntity());
+        
         PlanOptionDto.Request newPlanOption = PlanOptionDto.Request.builder()
-                .plan(savedPlan)
+                .plan(newPlan)
                 .build();
         planOptionRepository.save(newPlanOption.toEntity());
     }
@@ -45,16 +45,17 @@ public class PlanService {
     }
     
     @Transactional
-    public PlanDto.Response readPlanById(int app_user_id, int plan_id) {
-        Plan plan = planRepository.findByAppUserIdAndId(app_user_id, plan_id)
+    public PlanDto.Response readPlanById(int plan_id) {
+        Plan findPlan = planRepository.findById(plan_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
         
-        return new PlanDto.Response(plan);
+        return new PlanDto.Response(findPlan);
     }
     
     @Transactional
-    public List<PlanDto.Response> readPlanByPlanTag(int app_user_id, String planTag) {
-        List<Plan> findPlans = planRepository.findAllByAppUserIdAndPlanTag(app_user_id, planTag);
+    public List<PlanDto.Response> readPlanByPlanTag(String planTag) {
+        List<Plan> findPlans = planRepository.findAll()
+                .stream().filter(plan -> plan.getPlanTag().equals(planTag)).toList();
         
         if (findPlans.isEmpty())
             throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
@@ -64,16 +65,16 @@ public class PlanService {
     
     @Transactional
     public void updatePlan(int app_user_id, int plan_id, PlanDto.Request dto) {
-        Plan plan = planRepository.findByAppUserIdAndId(app_user_id, plan_id)
+        Plan findPlan = planRepository.findByAppUserIdAndId(app_user_id, plan_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
         
-        plan.update(dto.getPlanTag(), dto.getGoal(), dto.getPlanPhoto(), dto.isPublic(), dto.isComplete());
+        findPlan.update(dto.getPlanTag(), dto.getGoal(), dto.getPlanPhoto(), dto.isPublic(), dto.isComplete());
     }
     
     @Transactional
-    public void deletePlanById(int app_user_id, int plan_id) {
-        Plan plan = planRepository.findByAppUserIdAndId(app_user_id, plan_id)
+    public void deletePlanById(int plan_id) {
+        Plan findPlan = planRepository.findById(plan_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-        planRepository.delete(plan);
+        planRepository.delete(findPlan);
     }
 }

--- a/src/main/java/com/capstone/dayj/planOption/PlanOptionService.java
+++ b/src/main/java/com/capstone/dayj/planOption/PlanOptionService.java
@@ -25,12 +25,12 @@ public class PlanOptionService {
     
     @Transactional
     public void updatePlan(int app_user_id, int plan_id, PlanOptionDto.Request dto) {
-        List<Plan> plans = planRepository.findAllByAppUserId(app_user_id);
+        List<Plan> findPlans = planRepository.findAllByAppUserId(app_user_id);
         
-        if (plans.isEmpty())
+        if (findPlans.isEmpty())
             throw new CustomException(ErrorCode.PLAN_NOT_FOUND);
         
-        Plan findPlan = plans.stream().filter(plan -> plan.getId() == plan_id)
+        Plan findPlan = findPlans.stream().filter(plan -> plan.getId() == plan_id)
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
         PlanOption findPlanOption = findPlan.getPlanOption();

--- a/src/main/java/com/capstone/dayj/post/PostRepository.java
+++ b/src/main/java/com/capstone/dayj/post/PostRepository.java
@@ -11,13 +11,13 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Integer> {
     List<Post> findByPostTag(String postTag);
-
+    
     List<Post> findByPostTitleContainingOrPostContentContaining(String titleKeyword, String contentKeyword);
-
+    
     @Modifying
     @Query("UPDATE Post p set p.postView = p.postView + 1 where p.id = :postId")
     void incrementPostView(@Param("postId") int postId);
-
+    
     @Modifying
     @Query("UPDATE Post p set p.postLike = p.postLike + 1 where p.id = :postId")
     void incrementPostLike(@Param("postId") int postId);

--- a/src/main/java/com/capstone/dayj/post/PostService.java
+++ b/src/main/java/com/capstone/dayj/post/PostService.java
@@ -4,9 +4,9 @@ import com.capstone.dayj.appUser.AppUser;
 import com.capstone.dayj.appUser.AppUserRepository;
 import com.capstone.dayj.exception.CustomException;
 import com.capstone.dayj.exception.ErrorCode;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +17,6 @@ public class PostService {
     private final PostRepository postRepository;
     private final AppUserRepository appUserRepository;
     
-
     @Transactional
     public void createPost(PostDto.Request dto, int userId) {
         AppUser appUser = appUserRepository.findById(userId)
@@ -25,55 +24,55 @@ public class PostService {
         dto.setAppUser(appUser);
         postRepository.save(dto.toEntity());
     }
-
+    
     @Transactional(readOnly = true)
     public List<PostDto.Response> readAllPost() {
         List<Post> posts = postRepository.findAll();
-
+        
         if (posts.isEmpty())
             throw new CustomException(ErrorCode.POST_NOT_FOUND);
-
+        
         return posts.stream().map(PostDto.Response::new).collect(Collectors.toList());
     }
-
+    
     @Transactional
     public PostDto.Response readPostById(int id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-
+        
         postRepository.incrementPostView(id);
-
+        
         return new PostDto.Response(post);
     }
-
+    
     @Transactional(readOnly = true)
-    public List<PostDto.Response> readPostByTag(String tag){
+    public List<PostDto.Response> readPostByTag(String tag) {
         List<Post> posts = postRepository.findByPostTag(tag);
-
+        
         if (posts.isEmpty())
             throw new CustomException(ErrorCode.POST_NOT_FOUND);
-
+        
         return posts.stream().map(PostDto.Response::new).collect(Collectors.toList());
     }
-
+    
     @Transactional(readOnly = true)
     public List<PostDto.Response> searchPostsByKeyword(String keyword) {
         List<Post> posts = postRepository.findByPostTitleContainingOrPostContentContaining(keyword, keyword);
-
+        
         if (posts.isEmpty())
             throw new CustomException(ErrorCode.POST_NOT_FOUND);
-
+        
         return posts.stream().map(PostDto.Response::new).collect(Collectors.toList());
     }
-
+    
     @Transactional
     public void likePost(int postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-
+        
         postRepository.incrementPostLike(postId);
     }
-
+    
     @Transactional
     public void updatePost(int postId, PostDto.Request dto) {
         Post post = postRepository.findById(postId)
@@ -81,12 +80,12 @@ public class PostService {
         
         post.update(dto.getPostTitle(), dto.getPostContent(), dto.getPostTag(), dto.isPostIsAnonymous(), dto.getPostPhoto());
     }
-
+    
     @Transactional
     public void deletePostById(int postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-
+        
         postRepository.deleteById(post.getId());
     }
 }

--- a/src/main/java/com/capstone/dayj/setting/SettingService.java
+++ b/src/main/java/com/capstone/dayj/setting/SettingService.java
@@ -3,16 +3,16 @@ package com.capstone.dayj.setting;
 
 import com.capstone.dayj.exception.CustomException;
 import com.capstone.dayj.exception.ErrorCode;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class SettingService {
     private final SettingRepository settingRepository;
     
-    @Transactional
+    @Transactional(readOnly = true)
     public SettingDto.Response readSettingById(int app_user_id) {
         Setting findSetting = settingRepository.findByAppUserId(app_user_id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,3 @@ spring.jpa.defer-datasource-initialization=true
 spring.security.oauth2.client.registration.google.client-id=${CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=${SCOPE}
-#spring.security.oauth2.client.registration.google.redirect-uri=${RED_URI}


### PR DESCRIPTION
## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
* comment 엔티티에 parentId 필드를 추가하여 대댓글을 작성할 수 있도록 하였습니다. 
* 대댓글은 한 댓글에서 깊이가 1보다 커질 수 없습니다. 즉, 다음과 같은 상황만 가능합니다.

```
댓글
ㄴ---- 대댓글
ㄴ---- 대댓글
ㄴ---- 대댓글
X
```

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* 불필요한 pathParameter들을 제거해주는 작업을 진행했습니다.

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
* 대댓글 구현과정을 한 번 봐주시면 좋을 것 같습니다.
* 가장 중요하게 생각한 부분은 댓글이 지워졌을 때 어떡할 것인가에요. 이 부분에 대해서 부모 댓글이 지워져도 자식 댓글들이 부모의 id를 parentId에 저장하였으므로 여전히 가져올 수 있도록 구현해놓았습니다.

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item
