### PR TITLE
REFACTOR: FriendGroup 수정

### DIFF
--- a/src/main/java/com/capstone/dayj/appUser/AppUserRepository.java
+++ b/src/main/java/com/capstone/dayj/appUser/AppUserRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 public interface AppUserRepository extends JpaRepository<AppUser, Integer> {
      Optional<AppUser> findByName(String name);
      Optional<AppUser> findByEmail(String email);
-     List<AppUser> findByGroupMembers_FriendGroup_Id(int groupId);
 
+     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/capstone/dayj/appUser/AppUserService.java
+++ b/src/main/java/com/capstone/dayj/appUser/AppUserService.java
@@ -20,9 +20,9 @@ public class AppUserService {
     
     @Transactional
     public void createAppUser(AppUserDto.Request dto) {
-        AppUser appUser = appUserRepository.save(dto.toEntity());
+        AppUser savedAppUser = appUserRepository.save(dto.toEntity());
         SettingDto.Request newSetting = SettingDto.Request.builder()
-                .appUser(appUser)
+                .appUser(savedAppUser)
                 .build();
         settingRepository.save(newSetting.toEntity());
     }

--- a/src/main/java/com/capstone/dayj/appUser/AppUserService.java
+++ b/src/main/java/com/capstone/dayj/appUser/AppUserService.java
@@ -20,49 +20,52 @@ public class AppUserService {
     
     @Transactional
     public void createAppUser(AppUserDto.Request dto) {
-        AppUser savedAppUser = appUserRepository.save(dto.toEntity());
+        AppUser appUser = appUserRepository.save(dto.toEntity());
         SettingDto.Request newSetting = SettingDto.Request.builder()
-                .appUser(savedAppUser)
+                .appUser(appUser)
                 .build();
         settingRepository.save(newSetting.toEntity());
     }
     
     @Transactional(readOnly = true)
     public List<AppUserDto.Response> readAllAppUser() {
-        List<AppUser> appUsers = appUserRepository.findAll();
+        List<AppUser> findAppUsers = appUserRepository.findAll();
         
-        return appUsers.stream().map(AppUserDto.Response::new).collect(Collectors.toList());
+        return findAppUsers.stream().map(AppUserDto.Response::new).collect(Collectors.toList());
     }
     
     @Transactional(readOnly = true)
     public AppUserDto.Response readAppUserById(int id) {
-        AppUser appUser = appUserRepository.findById(id)
+        AppUser findAppUser = appUserRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
         
-        return new AppUserDto.Response(appUser);
+        return new AppUserDto.Response(findAppUser);
     }
     
     @Transactional(readOnly = true)
     public AppUserDto.Response readAppUserByEmail(String email) {
-        AppUser appUser = appUserRepository.findByEmail(email)
+        AppUser findAppUser = appUserRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
         
-        return new AppUserDto.Response(appUser);
+        return new AppUserDto.Response(findAppUser);
     }
     
     @Transactional
     public void updateAppUser(int id, AppUserDto.Request dto) {
-        AppUser existingAppUser = appUserRepository.findById(id)
+        if(appUserRepository.existsByNickname(dto.getNickname())) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+        AppUser findAppUser = appUserRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
-        
-        existingAppUser.update(dto.getNickname());
+
+        findAppUser.update(dto.getNickname());
     }
     
     @Transactional
     public void deleteAppUserById(int id) {
-        AppUser appUser = appUserRepository.findById(id)
+        AppUser findAppUser = appUserRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
         
-        appUserRepository.deleteById(appUser.getId());
+        appUserRepository.deleteById(findAppUser.getId());
     }
 }

--- a/src/main/java/com/capstone/dayj/exception/ErrorCode.java
+++ b/src/main/java/com/capstone/dayj/exception/ErrorCode.java
@@ -32,8 +32,11 @@ public enum ErrorCode {
     REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "대댓글을 찾을 수 없습니다."),
     
     // 404 POST_NOT_FOUND : 게시물을 찾을 수 없음
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다.");
-    
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
+
+    // 409 DUPLICATE_NICKNAME : 중복된 닉네임
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다.");
+
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/capstone/dayj/friendGroup/FriendGroupDto.java
+++ b/src/main/java/com/capstone/dayj/friendGroup/FriendGroupDto.java
@@ -35,19 +35,18 @@ public class FriendGroupDto {
         private final String groupGoal;
         private final String groupName;
         private final LocalDateTime createdAt;
+        private final List<GroupMemberDto.Response> achievementRates; // 달성률
         private final List<GroupMemberDto.Response> groupMember;
-        private final List<GroupMemberDto.achievementRateResponse> achievementRates; // 달성률
-        
         public Response(FriendGroup friendGroup, int app_user_id){
             this.id = friendGroup.getId();
             this.groupGoal = friendGroup.getGroupGoal();
             this.groupName = friendGroup.getGroupName();
             this.createdAt = friendGroup.getCreatedAt();
+            this.achievementRates = friendGroup.getGroupMember().stream()
+                    .map(GroupMemberDto.Response::new).collect(Collectors.toList());
             this.groupMember = friendGroup.getGroupMember().stream()
                     .filter(groupMember -> groupMember.getAppUser().getId() != app_user_id)
                     .map(GroupMemberDto.Response::new).collect(Collectors.toList());
-            this.achievementRates = friendGroup.getGroupMember().stream()
-                    .map(GroupMemberDto.achievementRateResponse::new).collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/com/capstone/dayj/friendGroup/FriendGroupDto.java
+++ b/src/main/java/com/capstone/dayj/friendGroup/FriendGroupDto.java
@@ -36,16 +36,19 @@ public class FriendGroupDto {
         private final String groupName;
         private final LocalDateTime createdAt;
         private final List<GroupMemberDto.Response> groupMember;
+        private final List<GroupMemberDto.achievementRateResponse> achievementRates; // 달성률
         
-        public Response(FriendGroup friendGroup){
+        public Response(FriendGroup friendGroup, int app_user_id){
             this.id = friendGroup.getId();
             this.groupGoal = friendGroup.getGroupGoal();
             this.groupName = friendGroup.getGroupName();
             this.createdAt = friendGroup.getCreatedAt();
-            this.groupMember = friendGroup.getGroupMember().stream().map(GroupMemberDto.Response::new).collect(Collectors.toList());
-
+            this.groupMember = friendGroup.getGroupMember().stream()
+                    .filter(groupMember -> groupMember.getAppUser().getId() != app_user_id)
+                    .map(GroupMemberDto.Response::new).collect(Collectors.toList());
+            this.achievementRates = friendGroup.getGroupMember().stream()
+                    .map(GroupMemberDto.achievementRateResponse::new).collect(Collectors.toList());
         }
-
     }
 }
 

--- a/src/main/java/com/capstone/dayj/friendGroup/FriendGroupService.java
+++ b/src/main/java/com/capstone/dayj/friendGroup/FriendGroupService.java
@@ -39,13 +39,17 @@ public class FriendGroupService {
 
     @Transactional(readOnly = true)
     public List<FriendGroupDto.Response> readAllFriendGroup(int app_user_id) {
+        AppUser findAppUser = appUserRepository.findById(app_user_id)
+                .orElseThrow(()-> new CustomException(ErrorCode.APP_USER_NOT_FOUND));
 
         List<FriendGroup> findFriendGroups = friendGroupRepository.findByGroupMember_AppUser_Id(app_user_id);
 
         if (findFriendGroups.isEmpty())
             throw new CustomException(ErrorCode.FRIEND_GROUP_NOT_FOUND);
-        
-        return findFriendGroups.stream().map(FriendGroupDto.Response::new).collect(Collectors.toList());
+
+        return findFriendGroups.stream()
+                .map(friendGroup -> new FriendGroupDto.Response(friendGroup, app_user_id))
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -54,7 +58,7 @@ public class FriendGroupService {
         FriendGroup findFriendGroup = friendGroupRepository.findByGroupMember_AppUser_IdAndId(app_user_id, group_id)
                 .orElseThrow(()-> new CustomException(ErrorCode.FRIEND_GROUP_NOT_FOUND));
 
-        return new FriendGroupDto.Response(findFriendGroup);
+        return new FriendGroupDto.Response(findFriendGroup, app_user_id);
     }
 
     @Transactional

--- a/src/main/java/com/capstone/dayj/groupMember/GroupMemberDto.java
+++ b/src/main/java/com/capstone/dayj/groupMember/GroupMemberDto.java
@@ -7,6 +7,9 @@ import com.capstone.dayj.plan.PlanDto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,14 +35,32 @@ public class GroupMemberDto {
     @Getter
     public static class Response {
         private final int id;
+        private final int appUserId;
         private final String nickname;
-        private final List<PlanDto.Response> groupMemberPlan;
-        
+        private final List<PlanDto.groupResponse> groupMemberPlan;
+
         public Response(GroupMember groupMember) {
             this.id = groupMember.getId();
+            this.appUserId = groupMember.getAppUser().getId();
             this.nickname = groupMember.getAppUser().getNickname();
             this.groupMemberPlan = groupMember.getAppUser().getPlans().stream()
-                    .filter(Plan::isPublic).map(PlanDto.Response::new).collect(Collectors.toList());
+                    .filter(plan -> plan.isPublic() && plan.getPlanOption().getPlanStartTime().toLocalDate().isEqual(LocalDate.now()))
+                    .map(PlanDto.groupResponse::new).collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    public static class achievementRateResponse {
+        private final int id;
+        private final int appUserId;
+        private final String nickname;
+//        private final int achievementRate;
+
+        public achievementRateResponse(GroupMember groupMember) {
+            this.id = groupMember.getId();
+            this.appUserId = groupMember.getAppUser().getId();
+            this.nickname = groupMember.getAppUser().getNickname();
+//            this.achievementRate =
         }
     }
 }

--- a/src/main/java/com/capstone/dayj/groupMember/GroupMemberDto.java
+++ b/src/main/java/com/capstone/dayj/groupMember/GroupMemberDto.java
@@ -37,30 +37,17 @@ public class GroupMemberDto {
         private final int id;
         private final int appUserId;
         private final String nickname;
+        private final int achievementRate;
         private final List<PlanDto.groupResponse> groupMemberPlan;
 
         public Response(GroupMember groupMember) {
             this.id = groupMember.getId();
             this.appUserId = groupMember.getAppUser().getId();
             this.nickname = groupMember.getAppUser().getNickname();
+            this.achievementRate = 99; // 통계 구현되면 수정 필요
             this.groupMemberPlan = groupMember.getAppUser().getPlans().stream()
                     .filter(plan -> plan.isPublic() && plan.getPlanOption().getPlanStartTime().toLocalDate().isEqual(LocalDate.now()))
                     .map(PlanDto.groupResponse::new).collect(Collectors.toList());
-        }
-    }
-
-    @Getter
-    public static class achievementRateResponse {
-        private final int id;
-        private final int appUserId;
-        private final String nickname;
-//        private final int achievementRate;
-
-        public achievementRateResponse(GroupMember groupMember) {
-            this.id = groupMember.getId();
-            this.appUserId = groupMember.getAppUser().getId();
-            this.nickname = groupMember.getAppUser().getNickname();
-//            this.achievementRate =
         }
     }
 }

--- a/src/main/java/com/capstone/dayj/plan/PlanDto.java
+++ b/src/main/java/com/capstone/dayj/plan/PlanDto.java
@@ -5,6 +5,8 @@ import com.capstone.dayj.planOption.PlanOption;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 public class PlanDto {
     @Data
     @AllArgsConstructor
@@ -57,6 +59,24 @@ public class PlanDto {
             this.isPublic = plan.isPublic();
             this.planOption = plan.getPlanOption();
             this.appUser = plan.getAppUser();
+        }
+    }
+    @Getter
+    public static class groupResponse {
+        private final int id;
+        private final String goal;
+        private final boolean isPublic;
+        private final boolean isComplete;
+        private final LocalDateTime planStartTime;
+        private final LocalDateTime planEndTime;
+
+        public groupResponse(Plan plan){
+            this.id = plan.getId();
+            this.goal = plan.getGoal();
+            this.isPublic = plan.isPublic();
+            this.isComplete = plan.isComplete();
+            this.planStartTime = plan.getPlanOption().getPlanStartTime();
+            this.planEndTime = plan.getPlanOption().getPlanEndTime();
         }
     }
 }

--- a/src/main/java/com/capstone/dayj/plan/PlanDto.java
+++ b/src/main/java/com/capstone/dayj/plan/PlanDto.java
@@ -65,18 +65,12 @@ public class PlanDto {
     public static class groupResponse {
         private final int id;
         private final String goal;
-        private final boolean isPublic;
         private final boolean isComplete;
-        private final LocalDateTime planStartTime;
-        private final LocalDateTime planEndTime;
 
         public groupResponse(Plan plan){
             this.id = plan.getId();
             this.goal = plan.getGoal();
-            this.isPublic = plan.isPublic();
             this.isComplete = plan.isComplete();
-            this.planStartTime = plan.getPlanOption().getPlanStartTime();
-            this.planEndTime = plan.getPlanOption().getPlanEndTime();
         }
     }
 }

--- a/src/main/java/com/capstone/dayj/post/PostDto.java
+++ b/src/main/java/com/capstone/dayj/post/PostDto.java
@@ -42,6 +42,7 @@ public class PostDto {
     @Getter
     public static class Response {
         private final int id;
+        private final int appUserId;
         private final int postView;
         private final int postLike;
         private final String postTitle;
@@ -57,6 +58,7 @@ public class PostDto {
         /* Entity -> Dto */
         public Response(Post post) {
             this.id = post.getId();
+            this.appUserId = post.getAppUser().getId();
             this.postView = post.getPostView();
             this.postLike = post.getPostLike();
             this.postTitle = post.getPostTitle();


### PR DESCRIPTION
## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- friendGroup 불러올 때 필요한 정보만 리턴하도록, 오늘 날짜의 plan만 리턴하도록 수정
- 앱유저 닉네임 수정 할 때, 타 유저와 중복된 닉네임 입력 시 409 예외 처리 추가
- postDto.Response에 작성자 id 필드 포함

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요
* appUserService 변수명 통일 
* planDto.groupResponse 테스트 완료해서 isPublic, startTime, endTime 필드는 삭제했습니다. 

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
- friendGroupDto - achievementRate, groupMember을 나눠놨습니다. 
- achievementRate는 유저 본인 정보까지 필요하고, groupMember는 유저 본인 정보 제외한 나머지 사람의 정보가 필요함, 프론트에서 나눠서 보내달라고 하셔서 나눠봤는데 더 좋은 방법 있으면 말씀해주세요 😭

---
## 📝 Assignee를 위한 CheckList
- [ ] To-Do Item
